### PR TITLE
fix copy to clipboard bug

### DIFF
--- a/sheet.html
+++ b/sheet.html
@@ -17,7 +17,7 @@
 
     });
     function copyToClipboard() {
-      const copyText = document.URL + '?' + ip_GenerateQueryStringFromGridData('demo');
+      const copyText = document.URL.split('?')[0]  + '?' + ip_GenerateQueryStringFromGridData('demo');
       navigator.clipboard.writeText(copyText).then(() => {
         $( "#popUp" ).show();
         setTimeout(function() { $( "#popUp" ).hide(); }, 2000);


### PR DESCRIPTION
split document.URL on '?' before appending the cell program - this stops copy to clipboard duplicating the cells list when editing an existing sheet.